### PR TITLE
Remove Goal.complete_for

### DIFF
--- a/lib/gamification/concerns/models/goal.rb
+++ b/lib/gamification/concerns/models/goal.rb
@@ -41,13 +41,4 @@ module Gamification::Concerns::Models::Goal
 
     class Completed < StandardError; end
   end
-
-  module ClassMethods
-    # Complete all goals for the given subject.
-    #
-    # subject - An ActiveRecord model that can receive rewards.
-    def complete_for subject
-      all.map { |goal| goal.complete_for subject unless goal.completed_by? subject }.compact
-    end
-  end
 end


### PR DESCRIPTION
This class method has some serious implications in that it overrides the
default scope of Gamification::Goal, causing it to be scoped to its
return value in subsequent invocations.

For example:

```
Gamification::Goal.count # => 3
Gamification::Goal.complete_for user
Gamification::Goal.count # => 1
```
