### PR TITLE
Verify rewards with a checksum

### DIFF
--- a/app/controllers/gamification/rewards_controller.rb
+++ b/app/controllers/gamification/rewards_controller.rb
@@ -2,45 +2,6 @@ require_dependency "gamification/application_controller"
 
 module Gamification
   class RewardsController < ApplicationController
-    def create
-      if rewarding.is_a? ::Gamification::Goal
-        rewarding.complete_for rewardable
-      else
-        rewarding.goals.each do |goal|
-          goal.complete_for rewardable
-        end
-      end
-
-      respond_to do |format|
-        format.json { render json: {}, status: :created }
-        format.html { redirect_to redirect_url }
-      end
-    end
-
-    private
-
-    def redirect_url
-      params[:redirect_url] || request.env['HTTP_REFERER']
-    end
-
-    def rewarding
-      rewarding_model.find reward_params[:rewarding_id]
-    end
-
-    def rewardable
-      rewardable_model.find reward_params[:rewardable_id]
-    end
-
-    def rewarding_model
-      reward_params[:rewarding_type].constantize
-    end
-
-    def rewardable_model
-      reward_params[:rewardable_type].constantize
-    end
-
-    def reward_params
-      params.require(:reward).permit(:rewarding_type, :rewarding_id, :rewardable_type, :rewardable_id)
-    end
+    include Gamification::Concerns::Controllers::RewardsController
   end
 end

--- a/app/helpers/gamification/application_helper.rb
+++ b/app/helpers/gamification/application_helper.rb
@@ -16,6 +16,9 @@ module Gamification
         concat hidden_field_tag 'reward[rewarding_id]', rewarding.id
         concat hidden_field_tag 'reward[rewardable_type]', rewardable.class.name
         concat hidden_field_tag 'reward[rewardable_id]', rewardable.id
+        concat hidden_field_tag 'checksum', Checksum.generate(
+          [rewarding.class.name, rewarding.id, rewardable.class.name, rewardable.id]
+        )
 
         if redirect
           concat hidden_field_tag 'redirect_url', redirect

--- a/lib/gamification.rb
+++ b/lib/gamification.rb
@@ -1,6 +1,7 @@
 require "gamification/engine"
 require "gamification/concerns"
 require "gamification/activerecord"
+require "gamification/checksum"
 
 module Gamification
 end

--- a/lib/gamification/checksum.rb
+++ b/lib/gamification/checksum.rb
@@ -1,0 +1,28 @@
+module Gamification
+  module Checksum
+    # Generate a checksum from the given values.
+    #
+    # values - An Array of values.
+    #
+    # Returns a String.
+    def self.generate values
+      Digest::MD5.hexdigest "#{secret_key}#{values.join}"
+    end
+
+    # Verify a given checksum against the given values.
+    #
+    # checksum - A String describing a checksum.
+    # values   - An Array of values.
+    #
+    # Returns a boolean.
+    def self.verify checksum, values
+      checksum == generate(values)
+    end
+
+    private
+
+    def self.secret_key
+      Rails.application.secrets[:secret_key_base]
+    end
+  end
+end

--- a/lib/gamification/concerns.rb
+++ b/lib/gamification/concerns.rb
@@ -1,5 +1,6 @@
 module Gamification::Concerns
   require "gamification/concerns/models"
+  require "gamification/concerns/controllers"
   require "gamification/concerns/rewarding"
   require "gamification/concerns/rewardable"
 end

--- a/lib/gamification/concerns/controllers.rb
+++ b/lib/gamification/concerns/controllers.rb
@@ -1,0 +1,3 @@
+module Gamification::Concerns::Controllers
+  require "gamification/concerns/controllers/rewards_controller"
+end

--- a/lib/gamification/concerns/controllers/rewards_controller.rb
+++ b/lib/gamification/concerns/controllers/rewards_controller.rb
@@ -1,0 +1,55 @@
+module Gamification
+  module Concerns::Controllers::RewardsController
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :verify_checksum
+
+      def create
+        if rewarding.is_a? ::Gamification::Goal
+          rewarding.complete_for rewardable
+        else
+          rewarding.goals.each do |goal|
+            goal.complete_for rewardable
+          end
+        end
+
+        respond_to do |format|
+          format.json { render json: {}, status: :created }
+          format.html { redirect_to redirect_url }
+        end
+      end
+
+      private
+
+      def verify_checksum
+        render text: "Invalid checksum", status: :forbidden unless Checksum.verify(params[:checksum], 
+          [rewarding.class.name, rewarding.id, rewardable.class.name, rewardable.id])
+      end
+
+      def redirect_url
+        params[:redirect_url] || request.env['HTTP_REFERER']
+      end
+
+      def rewarding
+        rewarding_model.find reward_params[:rewarding_id]
+      end
+
+      def rewardable
+        rewardable_model.find reward_params[:rewardable_id]
+      end
+
+      def rewarding_model
+        reward_params[:rewarding_type].constantize
+      end
+
+      def rewardable_model
+        reward_params[:rewardable_type].constantize
+      end
+
+      def reward_params
+        params.require(:reward).permit(:rewarding_type, :rewarding_id, :rewardable_type, :rewardable_id)
+      end
+    end
+  end
+end

--- a/spec/lib/gamification/checksum_spec.rb
+++ b/spec/lib/gamification/checksum_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Gamification::Checksum do
+  describe '.generate' do
+    it 'generates checksums' do
+      expect(subject.generate(['a', 'b', 'c'])).to eq('412ce96f60d05e18445b84f57a23ae22')
+    end
+  end
+
+  describe '.verify' do
+    it 'verifies checksums' do
+      expect(subject.verify('412ce96f60d05e18445b84f57a23ae22', ['a', 'b', 'c'])).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
This fixes a issue where an attacker could replay a request to grant themselves or others arbitrary rewards.