### PR TITLE
Prevent crash when "helper" is not defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ spec/dummy/log/*.log
 spec/dummy/tmp/
 spec/dummy/.sass-cache
 Gemfile.lock
+*.gem

--- a/gamification.gemspec
+++ b/gamification.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files      = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4.0"
+  s.add_dependency "rails", ">= 4.0"
   s.add_dependency "carrierwave", "~> 0.10"
   s.add_dependency "mini_magick", "~> 3.7"
 

--- a/lib/gamification/engine.rb
+++ b/lib/gamification/engine.rb
@@ -4,7 +4,7 @@ module Gamification
 
     initializer 'gamification.action_controller' do |app|
       ActiveSupport.on_load :action_controller do
-        helper Gamification::ApplicationHelper
+        helper Gamification::ApplicationHelper if defined?(helper)
       end
     end
 


### PR DESCRIPTION
Does 3 things:
- adds `*.gem` to `.gitignore`
- allows for Rails >= 4 instead of restricting to Rails 4
- checks if `helper` is defined before trying to call it when included
  - Rails 5 allows for api-only controllers, which do not have the `helper` method.